### PR TITLE
fix(ionic): build deps

### DIFF
--- a/apps/ionic-reservo-app/tsconfig.app.json
+++ b/apps/ionic-reservo-app/tsconfig.app.json
@@ -5,5 +5,8 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/test.ts", "src/**/*.spec.ts"]
+  "exclude": ["src/test.ts", "src/**/*.spec.ts"],
+  "angularCompilerOptions": {
+    "entryModule": "./src/app/app.module#AppModule"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@angular-devkit/architect": "^0.803.6",
-    "@angular/cli": "^8.3.6",
+    "@angular/cli": "~8.3.0",
     "@angular-devkit/build-angular": "^0.803.6",
     "@angular-devkit/core": "8.3.3",
     "@angular-devkit/schematics": "8.3.3",
@@ -100,8 +100,8 @@
     "protractor": "^5.4.2",
     "ts-jest": "24.0.0",
     "ts-node": "~7.0.0",
-    "tslint": "~5.11.0",
-    "typescript": "~3.4.5"
+    "tslint": "~5.20.0",
+    "typescript": "~3.5.3"
   },
   "xplat": {
     "prefix": "reservo-front",


### PR DESCRIPTION
@NicoForce Ok this fixes it. I believe it was just a typescript version compatibility issue but similar problems were mentioned here:
https://github.com/angular/angular-cli/issues/10516

After merging just do the following which will clean workspace and app:
```
npm run prepare.ionic.reservo-app 
```
Then you can dev ionic app in browser with:
```
nx serve ionic-reservo-app
```
All the other commands/scripts are relevant and should work as well like preparing for ios/android and capacitor.

I may update xplat ionic schematics to account for this as seems to only affect Ionic angular projects afaik. Cheers 👍 